### PR TITLE
Made mockneat code more idiomatic

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -157,7 +157,7 @@
 		<dependency>
 	        <groupId>net.andreinc.mockneat</groupId>
 	        <artifactId>mockneat</artifactId>
-	        <version>0.3.0</version>
+	        <version>0.3.2</version>
 	    </dependency>
 	    
 	    <!-- JUnit -->

--- a/backend/src/test/java/br/com/magazineluiza/v1/customers/generator/AddressGenerator.java
+++ b/backend/src/test/java/br/com/magazineluiza/v1/customers/generator/AddressGenerator.java
@@ -3,25 +3,32 @@ package br.com.magazineluiza.v1.customers.generator;
 import br.com.magazineluiza.v1.customers.entity.AddressEntity;
 import br.com.magazineluiza.v1.customers.entity.AddressEntityPK;
 import net.andreinc.mockneat.MockNeat;
+import net.andreinc.mockneat.abstraction.MockConstValue;
 import net.andreinc.mockneat.abstraction.MockUnit;
 
+import static net.andreinc.mockneat.unit.address.Cities.cities;
+import static net.andreinc.mockneat.unit.objects.Filler.filler;
+import static net.andreinc.mockneat.unit.objects.From.from;
+import static net.andreinc.mockneat.unit.text.Strings.strings;
+import static net.andreinc.mockneat.unit.types.Ints.ints;
+
 public class AddressGenerator {
-	private final MockNeat mock = MockNeat.threadLocal();
 	
 	public MockUnit<AddressEntity> schema(Long customerId) {
-		Integer id = this.mock.ints().get();
-		return this.mock.filler(() -> new AddressEntity())
-	    	.setter(AddressEntity::setCity, this.mock.strings())
-	    	.setter(AddressEntity::setPk, this.mock.filler(() -> new AddressEntityPK())
-    			.setter(AddressEntityPK::setId, this.mock.from(new Integer[] { id }))
-    			.setter(AddressEntityPK::setCustomerId, this.mock.from(new Long[] { customerId })))
-	        .setter(AddressEntity::setId, this.mock.from(new Integer[] { id }))
-	        .setter(AddressEntity::setComplement, this.mock.strings())
-	        .setter(AddressEntity::setDistrict, this.mock.strings())
-	        .setter(AddressEntity::setNumber, this.mock.ints())
-	        .setter(AddressEntity::setState, this.mock.from(new String[] { "PR", "SP", "RS" }))
-	        .setter(AddressEntity::setStreetType, this.mock.from(new String[] { "R", "AV" }))
-	        .setter(AddressEntity::setStreet, this.mock.strings())
-	        .setter(AddressEntity::setZipCode, this.mock.strings().size(8));
+		Integer id = ints().get();
+
+		return filler(AddressEntity::new)
+				.setter(AddressEntity::setCity, cities().us())
+				.setter(AddressEntity::setPk, filler(AddressEntityPK::new)
+												.constant(AddressEntityPK::setId, id)
+												.constant(AddressEntityPK::setCustomerId, customerId))
+				.constant(AddressEntity::setId, id)
+				.setter(AddressEntity::setComplement, strings())
+				.setter(AddressEntity::setDistrict, strings())
+				.setter(AddressEntity::setNumber, ints())
+				.setter(AddressEntity::setState, from(new String[] { "PR", "SP", "RS" }))
+				.setter(AddressEntity::setStreetType, from(new String[] { "R", "AV" }))
+				.setter(AddressEntity::setStreet, strings())
+				.setter(AddressEntity::setZipCode, strings().size(8));
 	}
 }

--- a/backend/src/test/java/br/com/magazineluiza/v1/customers/generator/BaseGenerator.java
+++ b/backend/src/test/java/br/com/magazineluiza/v1/customers/generator/BaseGenerator.java
@@ -4,8 +4,8 @@ import net.andreinc.mockneat.MockNeat;
 import net.andreinc.mockneat.abstraction.MockUnit;
 
 public class BaseGenerator<T> {
-	protected static final MockNeat mock = MockNeat.threadLocal();
 	private MockUnit<T> mockSchema;
+
 	public BaseGenerator(MockUnit<T> mockSchema) {
 		this.setMockSchema(mockSchema);
 	}

--- a/backend/src/test/java/br/com/magazineluiza/v1/customers/generator/BranchGenerator.java
+++ b/backend/src/test/java/br/com/magazineluiza/v1/customers/generator/BranchGenerator.java
@@ -4,11 +4,13 @@ import net.andreinc.mockneat.MockNeat;
 import net.andreinc.mockneat.abstraction.MockUnit;
 import br.com.magazineluiza.v1.customers.entity.BranchEntity;
 
+import static net.andreinc.mockneat.unit.objects.Filler.filler;
+import static net.andreinc.mockneat.unit.types.Ints.ints;
+
 public class BranchGenerator {
-	private final MockNeat mock = MockNeat.threadLocal();
 	
 	public MockUnit<BranchEntity> schema() {
-		return this.mock.filler(() -> new BranchEntity())
-			.setter(BranchEntity::setId, this.mock.ints());
+		return filler(BranchEntity::new)
+				.setter(BranchEntity::setId, ints());
 	}
 }

--- a/backend/src/test/java/br/com/magazineluiza/v1/customers/generator/CustomerGenerator.java
+++ b/backend/src/test/java/br/com/magazineluiza/v1/customers/generator/CustomerGenerator.java
@@ -5,8 +5,16 @@ import net.andreinc.mockneat.abstraction.MockUnit;
 import net.andreinc.mockneat.types.enums.StringType;
 import br.com.magazineluiza.v1.customers.entity.CustomerEntity;
 
+import static net.andreinc.mockneat.types.enums.StringType.NUMBERS;
+import static net.andreinc.mockneat.unit.objects.Filler.filler;
+import static net.andreinc.mockneat.unit.objects.From.from;
+import static net.andreinc.mockneat.unit.text.Strings.strings;
+import static net.andreinc.mockneat.unit.types.Ints.ints;
+import static net.andreinc.mockneat.unit.types.Longs.longs;
+import static net.andreinc.mockneat.unit.user.Names.names;
+
 public class CustomerGenerator {
-	private final MockNeat mock = MockNeat.threadLocal();
+
 	private final BranchGenerator branchGenerator;
 	private final AddressGenerator addressGenerator;
 	
@@ -16,14 +24,14 @@ public class CustomerGenerator {
 	}
 	
 	public MockUnit<CustomerEntity> schema() {
-		Long id = this.mock.longs().get();
-		return this.mock.filler(() -> new CustomerEntity())
-	    	.setter(CustomerEntity::setName, this.mock.names().first())
-	        .setter(CustomerEntity::setId, this.mock.from(new Long[] { id }))
-	        .setter(CustomerEntity::setNatJur, this.mock.from(new String[]{"F", "J"}))
-	        .setter(CustomerEntity::setDigit, this.mock.from(new Integer[] { 0, 1, 2, 3, 4, 6, 7, 8, 9 }))
-	        .setter(CustomerEntity::setCpf, this.mock.strings().size(11).type(StringType.NUMBERS))
-	        .setter(CustomerEntity::setCnpj, this.mock.strings().size(14).type(StringType.NUMBERS))
+		Long id = longs().get();
+		return filler(CustomerEntity::new)
+	    	.setter(CustomerEntity::setName, names().first())
+	        .constant(CustomerEntity::setId, id)
+	        .setter(CustomerEntity::setNatJur, from(new String[]{"F", "J"}))
+	        .setter(CustomerEntity::setDigit, ints().range(0, 10))
+	        .setter(CustomerEntity::setCpf, strings().size(11).type(NUMBERS))
+	        .setter(CustomerEntity::setCnpj, strings().size(14).type(NUMBERS))
 	        .setter(CustomerEntity::setBranch, this.branchGenerator.schema())
 	        .setter(CustomerEntity::setAddress, this.addressGenerator.schema(id).list(2));
 	}

--- a/backend/src/test/java/br/com/magazineluiza/v1/customers/generator/SigninGenerator.java
+++ b/backend/src/test/java/br/com/magazineluiza/v1/customers/generator/SigninGenerator.java
@@ -4,11 +4,13 @@ import net.andreinc.mockneat.MockNeat;
 import net.andreinc.mockneat.abstraction.MockUnit;
 import br.com.magazineluiza.v1.customers.entity.SigninEntity;
 
+import static net.andreinc.mockneat.unit.objects.Filler.filler;
+import static net.andreinc.mockneat.unit.text.Strings.strings;
+
 public class SigninGenerator {
-	private final MockNeat mock = MockNeat.threadLocal();
 	
 	public MockUnit<SigninEntity> schema() {
-		return this.mock.filler(() -> new SigninEntity())
-			.setter(SigninEntity::setToken, this.mock.strings().size(10));
+		return filler(SigninEntity::new)
+				.setter(SigninEntity::setToken, strings().size(10));
 	}
 }


### PR DESCRIPTION
This is a proposal to make the mockneat code more idiomatic.

I've seen you were struggling with `m.from(new T[] { t })` to set a constant value for a specific field so I've added a new method "constant()" that will allow you do that.

Thanks for trying mockneat!